### PR TITLE
feat(admin/solo-projects): force dynamic rendering on TierMismatch page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.6.0](https://github.com/cherylli/chingu-soloproject-evaluation-app/compare/v1.5.0...v1.6.0) (2025-07-31)
+
+
+### Miscellaneous Chores
+
+* release 1.6.0 ([e70ef94](https://github.com/cherylli/chingu-soloproject-evaluation-app/commit/e70ef94e79f32ef8b00ca224e2a53b48a9268cc0))
+
 ## [1.5.0](https://github.com/cherylli/chingu-soloproject-evaluation-app/compare/v1.4.0...v1.5.0) (2025-07-17)
 
 

--- a/src/app/admin/solo-project/tier-mismatch/page.tsx
+++ b/src/app/admin/solo-project/tier-mismatch/page.tsx
@@ -1,3 +1,4 @@
+export const dynamic = 'force-dynamic'
 import {getTierMismatchedSoloProjects} from "@/services/soloProjects";
 import TierMismatchTable from "@/components/soloprojects/tiers/TierMismatchTable";
 import H1 from "@/components/ui/typography/h1";


### PR DESCRIPTION
make tier mismatch page (`/admin/solo-project/tier-mismatch`) dynamic. It was static by default