### PR TITLE
Admin-Only Airtable Links for Solo Projects

### DIFF
--- a/src/app/solo-project/[id]/page.tsx
+++ b/src/app/solo-project/[id]/page.tsx
@@ -8,6 +8,7 @@ import FeedbackContainer from "@/components/feedback/FeedbackContainer";
 import CompactList from "@/components/soloprojects/CompactList";
 import ReadOnly from "@/components/soloprojects/details/ReadOnly";
 import { ResizableHandle, ResizablePanel, ResizablePanelGroup } from "@/components/ui/resizable";
+import {getAtTableBaseUrl} from "@/lib/getAtTableBaseUrl";
 
 const SoloProjectPage = async (props: { params: Promise<{ id: string }> }) => {
     const params = await props.params;
@@ -30,6 +31,7 @@ const SoloProjectPage = async (props: { params: Promise<{ id: string }> }) => {
                         {projects.length > 1 && <CompactList records={projects}/>}
                         <ProjectSubmissionDetail
                             record={record}
+                            atBaseUrl={getAtTableBaseUrl('solo-project')}
                         />
                         <Comments recordId={params.id}/>
                     </div>

--- a/src/components/soloprojects/FetchProjects.tsx
+++ b/src/components/soloprojects/FetchProjects.tsx
@@ -4,6 +4,7 @@ import SoloProjectTable from "@/components/soloprojects/soloProjectTable";
 import {revalidatePath} from "next/cache";
 import {RefreshData} from "@/lib/RefreshData";
 import ClientDateTime from "@/components/ClientDateTime";
+import {getAtTableBaseUrl} from "@/lib/getAtTableBaseUrl";
 
 const FetchProjects = async ({
                                  status = "Waiting Eval",
@@ -25,7 +26,10 @@ const FetchProjects = async ({
                 <CardContent>{noRecordMessage}</CardContent>
             </Card>
             : <>
-                <SoloProjectTable records={records}/>
+                <SoloProjectTable
+                    records={records}
+                    baseUrl={getAtTableBaseUrl('solo-project')}
+                />
             </>
     }
         <RefreshData ms={10*60*1000} refreshAction={refreshRecords} />

--- a/src/components/soloprojects/columnDef.tsx
+++ b/src/components/soloprojects/columnDef.tsx
@@ -5,19 +5,22 @@ import {getRole} from "@/lib/getRole";
 import Link from "next/link";
 import {SiAirtable} from "@icons-pack/react-simple-icons";
 
+
 const columnHelper = createColumnHelper<Submission>()
 
 export const columnDef = (
-    baseURL: string
+    baseURL: string,
+    isAdmin: boolean = false
 ) => [
-    columnHelper.display({
+    ...(isAdmin ?
+    [columnHelper.display({
         id: "Airtable Link",
         cell: ({row}) => {
             return <a href={`${baseURL}/${row.original.id}`} target="_blank" rel="noreferrer">
                 <SiAirtable />
             </a>
         }
-    }),
+    })]:[]),
     columnHelper.accessor((row) => row.fields["Discord Name"], {
         id: "Discord Name",
         header: "Discord Name",

--- a/src/components/soloprojects/columnDef.tsx
+++ b/src/components/soloprojects/columnDef.tsx
@@ -3,10 +3,21 @@ import {Submission} from "@/types/SoloProjectTypes";
 import {roleColors} from "@/styles/roles";
 import {getRole} from "@/lib/getRole";
 import Link from "next/link";
+import {SiAirtable} from "@icons-pack/react-simple-icons";
 
 const columnHelper = createColumnHelper<Submission>()
 
-export const columnDef = [
+export const columnDef = (
+    baseURL: string
+) => [
+    columnHelper.display({
+        id: "Airtable Link",
+        cell: ({row}) => {
+            return <a href={`${baseURL}/${row.original.id}`} target="_blank" rel="noreferrer">
+                <SiAirtable />
+            </a>
+        }
+    }),
     columnHelper.accessor((row) => row.fields["Discord Name"], {
         id: "Discord Name",
         header: "Discord Name",

--- a/src/components/soloprojects/details/BaseDetails.tsx
+++ b/src/components/soloprojects/details/BaseDetails.tsx
@@ -20,18 +20,25 @@ import UIUXDetails from "@/components/soloprojects/details/UIUXDetails";
 import { BaseDetailHeader } from "@/components/soloprojects/details/BaseDetailsHeader";
 import TierSuggestion from "@/components/soloprojects/tiers/TierSuggestion";
 import {removeEvaluatorOnDb, setEvaluatorOnDb, updateSoloProjectById} from "@/services/soloProjects";
+import {SiAirtable} from "@icons-pack/react-simple-icons";
+import {useRoleCheck} from "@/hooks/useRoleCheck";
+
 
 interface ProjectDetailProps {
     record: Submission
+    atBaseUrl: string
 }
 
+
 const ProjectSubmissionDetail = (
-    {record: initialRecord}: ProjectDetailProps
+    {record: initialRecord, atBaseUrl}: ProjectDetailProps
 ) => {
     const [statusOpen, setStatusOpen] = useState(false)
     const [ringTheBellText, setRingTheBellText] = useState('')
     const [selectionLen, setSelectionLen] = useState(0)
     const [record, setRecord] = useState<Submission>(initialRecord)
+
+    const { isAdmin } = useRoleCheck()
 
     if(!record) return
 
@@ -113,10 +120,19 @@ const ProjectSubmissionDetail = (
         })
     }
 
+
+
     return <div>
         <section className="flex flex-col gap-5 w-[90%] mx-auto">
             <BaseDetailHeader record={record} />
-            <div>{record.fields["Timestamp"].toString()}</div>
+            <div className="flex gap-5 items-center">
+                {
+                    isAdmin && <a href={`${atBaseUrl}/${record.id}`} target="_blank" rel="noreferrer" >
+                        <SiAirtable/>
+                    </a>
+                }
+                <div>{record.fields["Timestamp"].toString()}</div>
+            </div>
             <div className="flex gap-5 items-center">
                 <div>{record.fields.Tier}</div>
                 <TierSuggestion onSuccess={updateRecordFields}/>

--- a/src/components/soloprojects/soloProjectTable.tsx
+++ b/src/components/soloprojects/soloProjectTable.tsx
@@ -1,11 +1,11 @@
 'use client'
 
 import {Submission} from "@/types/SoloProjectTypes";
-
 import {columnDef} from "@/components/soloprojects/columnDef";
 import {getCoreRowModel} from "@tanstack/table-core";
 import {useReactTable} from "@tanstack/react-table";
 import StandardReactTable from "@/components/react-table/StandardReactTable";
+import {useSession} from "next-auth/react";
 
 
 const SoloProjectTable = ({
@@ -16,9 +16,13 @@ const SoloProjectTable = ({
     }
 ) => {
 
+    const {data: sessionData } = useSession()
+    const userRole = sessionData?.user?.roles || []
+    const isAdmin = userRole.includes("admin")
+
     const spTable = useReactTable<Submission>({
         data: records,
-        columns: columnDef(baseUrl),
+        columns: columnDef(baseUrl, isAdmin),
         getCoreRowModel: getCoreRowModel<Submission>()
     })
 

--- a/src/components/soloprojects/soloProjectTable.tsx
+++ b/src/components/soloprojects/soloProjectTable.tsx
@@ -8,16 +8,21 @@ import {useReactTable} from "@tanstack/react-table";
 import StandardReactTable from "@/components/react-table/StandardReactTable";
 
 
-
-const SoloProjectTable = ({records}: { records: Submission[] }) => {
+const SoloProjectTable = ({
+        records, baseUrl
+    }: {
+        records: Submission[],
+        baseUrl: string
+    }
+) => {
 
     const spTable = useReactTable<Submission>({
         data: records,
-        columns: columnDef,
+        columns: columnDef(baseUrl),
         getCoreRowModel: getCoreRowModel<Submission>()
     })
 
-    return <StandardReactTable table={spTable} />
+    return <StandardReactTable table={spTable}/>
 }
 
 export default SoloProjectTable

--- a/src/hooks/useRoleCheck.ts
+++ b/src/hooks/useRoleCheck.ts
@@ -1,0 +1,12 @@
+import { useSession } from "next-auth/react";
+
+
+export const useRoleCheck = () => {
+    const { data: session, status } = useSession()
+
+    return {
+        isAdmin: session?.user.roles.includes("admin"),
+        isEvaluator: session?.user.roles.includes("evaluator"),
+        isLoading: status === "loading"
+    }
+}

--- a/src/lib/airtable.ts
+++ b/src/lib/airtable.ts
@@ -291,7 +291,6 @@ export const createOrFilter = (
         value: string
     }[]
 ): string => {
-    console.log("createORFilter - conditions", conditions)
     if (conditions.length === 0) {
         throw new Error("[CreateOrFilter]: At least one condition must be provided.")
     }
@@ -299,8 +298,6 @@ export const createOrFilter = (
     const filterFields = conditions.map(({field, value})=>{
         return `{${field}} = "${value}"`
     })
-
-    console.log("createORFilter - filterFields", filterFields)
 
     return `OR(${filterFields.join(",")})`
 }


### PR DESCRIPTION
This PR adds admin-only Airtable links to the solo projects interface, allowing administrators to quickly access and edit records directly in Airtable.

**Changes:**
- Added Airtable link column to solo project table (visible to admins only)
- Added Airtable link to solo project detail pages (admin-only)
- Created hook for role-based conditional rendering `useRoleCheck`
- Updated table components to support dynamic base URLs

**Features:**
- 🔒 Admin-only visibility using role-based authentication
- 🔗 Direct links to Airtable records for quick editing
- 🎯 Clean conditional rendering with custom hook
